### PR TITLE
Show the popup only it the player didn't have the achievement

### DIFF
--- a/AchievementTracker/AchievementManager.cs
+++ b/AchievementTracker/AchievementManager.cs
@@ -88,10 +88,12 @@ namespace AchievementTracker
         {
             if (!_achievements.TryGetValue(uniqueID, out AchievementInfo achievement)) return;
 
-            Logger.Log($"Earned achievement! [{achievement.ModName}] [{achievement.GetName()}] [{achievement.GetDescription()}]");
-            AchievementData.EarnAchievement(uniqueID);
-
-            AchievementPopup.Show(achievement);
+            if (!AchievementData.HasAchievement(uniqueID))
+            {
+                Logger.Log($"Earned achievement! [{achievement.ModName}] [{achievement.GetName()}] [{achievement.GetDescription()}]");
+                AchievementData.EarnAchievement(uniqueID);
+                AchievementPopup.Show(achievement);
+            }
         }
 
         public static Dictionary<string, AchievementInfo> GetAchievements()

--- a/AchievementTracker/manifest.json
+++ b/AchievementTracker/manifest.json
@@ -3,7 +3,7 @@
   "author": "xen",
   "name": "Achievements+",
   "uniqueName": "xen.AchievementTracker",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "owmlVersion": "2.0.0",
   "priorityLoad": true
 }


### PR DESCRIPTION
This way the modder doesn't have to keeep track of earned achievements before calling `EarnAchievement`. Stock achievements are also calling this multiple times, so this PR also fixes that case.